### PR TITLE
remove double-quotes from Observation sql

### DIFF
--- a/jhe/core/models.py
+++ b/jhe/core/models.py
@@ -748,7 +748,7 @@ class Observation(models.Model):
             JOIN core_organization ON core_organization.id=core_patient.organization_id
             JOIN core_jheuserorganization ON core_jheuserorganization.organization_id=core_organization.id
             WHERE core_jheuserorganization.jhe_user_id={jhe_user_id}
-            core_codeableconcept.coding_system LIKE '%(coding_system)s' AND core_codeableconcept.coding_code LIKE '%(coding_code)s'
+            core_codeableconcept.coding_system LIKE %(coding_system)s AND core_codeableconcept.coding_code LIKE %(coding_code)s
             {study_sql_where}
             {patient_sql_where}
             {observation_sql_where}


### PR DESCRIPTION
quotes [shouldn't be added](https://docs.djangoproject.com/en/5.1/topics/db/sql/#passing-parameters-into-raw) around placeholder fields, causes syntax errors because django already quotes parameters, resulting in:

```
syntax error at or near "core_codeableconcept"
LINE 47:             core_codeableconcept.coding_system LIKE ''*'' AN...
```

follow-up to #31 

I can't test this, but it would be good to verify that the fhir Observation endpoint works when deploying this, in case more patches are needed