### PR TITLE
Add icon images for studies - backend

### DIFF
--- a/jhe/core/models.py
+++ b/jhe/core/models.py
@@ -384,6 +384,7 @@ class Study(models.Model):
     description = models.TextField()
     organization = models.ForeignKey(Organization, on_delete=models.CASCADE)
     patients = models.ManyToManyField('Patient', through='StudyPatient')
+    icon_url = models.TextField(null=True, blank=True)
 
     @staticmethod
     def for_practitioner_organization(practitioner_user_id, organization_id=None, study_id=None):

--- a/jhe/core/serializers.py
+++ b/jhe/core/serializers.py
@@ -65,7 +65,7 @@ class StudySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Study
-        fields = ['id', 'name', 'description', 'organization']
+        fields = ['id', 'name', 'description', 'organization', 'icon_url']
 
 
 class StudyOrganizationSerializer(serializers.ModelSerializer):
@@ -74,7 +74,7 @@ class StudyOrganizationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Study
-        fields = ['id', 'name', 'description', 'organization']
+        fields = ['id', 'name', 'description', 'organization', 'icon_url']
 
 
 class StudyPatientSerializer(serializers.ModelSerializer):

--- a/jhe/core/static/client.js
+++ b/jhe/core/static/client.js
@@ -761,6 +761,7 @@ async function createStudy() {
     organization: parseInt(
       document.getElementById("studyOrganizationId").value
     ),
+    icon_url: document.getElementById("studyIconUrl").value || null
   };
   const response = await apiRequest("POST", `studies`, studyRecord);
   if (response.ok) navReturnFromCrud();
@@ -770,6 +771,7 @@ async function updateStudy(id) {
   const studyRecord = {
     name: document.getElementById("studyName").value || null,
     description: document.getElementById("studyDescription").value || null,
+    icon_url: document.getElementById("studyIconUrl").value || null
   };
   const response = await apiRequest("PATCH", `studies/${id}`, studyRecord);
   if (response.ok) navReturnFromCrud();
@@ -1225,4 +1227,58 @@ async function debugDoObservations() {
     null,
     2
   );
+}
+
+let iconPreviewTimeout;
+
+function previewIcon(input) {
+  if (iconPreviewTimeout) {
+    clearTimeout(iconPreviewTimeout);
+  }
+
+  const previewContainer = document.getElementById('iconPreview');
+  const url = input.value.trim();
+
+  previewContainer.innerHTML = '';
+  clearModalValidationErrors();
+
+  if (!url) {
+    previewContainer.innerHTML = `
+      <div class="text-center text-muted" style="height: 100%; line-height: 46px;">
+        <i class="bi bi-image"></i>
+      </div>`;
+    return;
+  }
+
+  previewContainer.innerHTML = `
+    <div class="text-center text-muted" style="height: 100%; line-height: 46px;">
+      <i class="bi bi-arrow-repeat"></i>
+    </div>`;
+
+  iconPreviewTimeout = setTimeout(() => {
+    const img = document.createElement('img');
+    img.src = url;
+    img.alt = 'Icon';
+    img.style.cssText = 'width: 100%; height: 100%; object-fit: cover;';
+    
+    const errorDiv = document.createElement('div');
+    errorDiv.className = 'text-center text-muted';
+    errorDiv.style.cssText = 'display: none; height: 100%; line-height: 46px;';
+    errorDiv.innerHTML = '<i class="bi bi-exclamation-triangle"></i>';
+
+    img.onerror = () => {
+      img.style.display = 'none';
+      errorDiv.style.display = 'block';
+      displayModalValidationError(['Unable to load image from URL. Please check the URL and try again.']);
+    };
+
+    img.onload = () => {
+      errorDiv.style.display = 'none';
+      clearModalValidationErrors();
+    };
+
+    previewContainer.innerHTML = '';
+    previewContainer.appendChild(img);
+    previewContainer.appendChild(errorDiv);
+  }, 500);
 }

--- a/jhe/core/static/client.js
+++ b/jhe/core/static/client.js
@@ -692,7 +692,7 @@ async function renderStudies(queryParams) {
           iconUrlInput.value = studyRecord.iconUrl;
           previewIcon(iconUrlInput);
         }
-      }, 100);
+      }, 500);
     }
 
     if (queryParams.read) {

--- a/jhe/core/static/client.js
+++ b/jhe/core/static/client.js
@@ -711,6 +711,8 @@ async function renderStudies(queryParams) {
         (dataSource) => dataSourceIds.indexOf(dataSource.id) == -1
       );
 
+      console.log(studyRecord.dataSources);
+
       const studyScopesRequestedResponse = await apiRequest(
         "GET",
         `studies/${queryParams.id}/scope_requests`

--- a/jhe/core/static/client.js
+++ b/jhe/core/static/client.js
@@ -685,6 +685,16 @@ async function renderStudies(queryParams) {
     );
     studyRecord = await studyRecordResponse.json();
 
+    if (studyRecord.iconUrl) {
+      setTimeout(() => {
+        const iconUrlInput = document.getElementById("studyIconUrl");
+        if (iconUrlInput) {
+          iconUrlInput.value = studyRecord.iconUrl;
+          previewIcon(iconUrlInput);
+        }
+      }, 100);
+    }
+
     if (queryParams.read) {
       const studyDataSourcesResponse = await apiRequest(
         "GET",
@@ -700,8 +710,6 @@ async function renderStudies(queryParams) {
       allDataSources.results = allDataSources.results.filter(
         (dataSource) => dataSourceIds.indexOf(dataSource.id) == -1
       );
-
-      console.log(studyRecord.dataSources);
 
       const studyScopesRequestedResponse = await apiRequest(
         "GET",
@@ -761,7 +769,7 @@ async function createStudy() {
     organization: parseInt(
       document.getElementById("studyOrganizationId").value
     ),
-    icon_url: document.getElementById("studyIconUrl").value || null
+    iconUrl: document.getElementById("studyIconUrl").value || null
   };
   const response = await apiRequest("POST", `studies`, studyRecord);
   if (response.ok) navReturnFromCrud();
@@ -771,7 +779,7 @@ async function updateStudy(id) {
   const studyRecord = {
     name: document.getElementById("studyName").value || null,
     description: document.getElementById("studyDescription").value || null,
-    icon_url: document.getElementById("studyIconUrl").value || null
+    iconUrl: document.getElementById("studyIconUrl").value || null
   };
   const response = await apiRequest("PATCH", `studies/${id}`, studyRecord);
   if (response.ok) navReturnFromCrud();

--- a/jhe/core/templates/client/client_templates/studies.html
+++ b/jhe/core/templates/client/client_templates/studies.html
@@ -152,7 +152,7 @@
                   >{{studyRecord.description}}</textarea>
                 </div>
                 <div class="mb-3">
-                  <label for="iconUrl" class="form-label">Icon URL</label>
+                  <label for="studyIconUrl" class="form-label">Icon URL</label>
                   <div class="d-flex align-items-center gap-3">
                     <div id="iconPreview" class="study-icon-preview" style="width: 48px; height: 48px; border: 1px solid #dee2e6; border-radius: 4px; overflow: hidden;">
                       <div class="text-center text-muted" style="height: 100%; line-height: 46px;">
@@ -162,8 +162,9 @@
                     <input
                       type="url"
                       class="form-control"
-                      id="iconUrl"
+                      id="studyIconUrl"
                       placeholder="Enter icon URL"
+                      value="{{studyRecord.icon_url}}"
                       onchange="previewIcon(this)"
                       oninput="previewIcon(this)"
                     />

--- a/jhe/core/templates/client/client_templates/studies.html
+++ b/jhe/core/templates/client/client_templates/studies.html
@@ -152,6 +152,24 @@
                   >{{studyRecord.description}}</textarea>
                 </div>
                 <div class="mb-3">
+                  <label for="iconUrl" class="form-label">Icon URL</label>
+                  <div class="d-flex align-items-center gap-3">
+                    <div id="iconPreview" class="study-icon-preview" style="width: 48px; height: 48px; border: 1px solid #dee2e6; border-radius: 4px; overflow: hidden;">
+                      <div class="text-center text-muted" style="height: 100%; line-height: 46px;">
+                        <i class="bi bi-image"></i>
+                      </div>
+                    </div>
+                    <input
+                      type="url"
+                      class="form-control"
+                      id="iconUrl"
+                      placeholder="Enter icon URL"
+                      onchange="previewIcon(this)"
+                      oninput="previewIcon(this)"
+                    />
+                  </div>
+                </div>
+                <div class="mb-3">
                   <fieldset disabled>
                     <label for="studyOrganizationName" class="form-label"
                       >Organization Name</label


### PR DESCRIPTION
- Used a branch with a frontend implemention.
- Create an `icon_url` TextField.
- Update the client side for Study CRUD operations.
- Tested by creating a new study, updating study and deleting study.

<img width="1199" alt="image" src="https://github.com/user-attachments/assets/0d359af8-728e-4530-8905-c3ed2accc525" />

View Study
<img width="1205" alt="image" src="https://github.com/user-attachments/assets/3a44ec26-041c-4cdd-a9e8-27c1ccd23e57" />

Update Study (text field is editable)
<img width="1205" alt="image" src="https://github.com/user-attachments/assets/f7d4b4f0-e2f1-4bb4-8e7e-aad277ad117e" />

Delete Study
<img width="1205" alt="image" src="https://github.com/user-attachments/assets/ab77bd92-0563-4097-be5d-ec396fb15810" />
